### PR TITLE
Add PostHog tracking integration

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -219,5 +219,10 @@
     "socials": {
       "x": "https://x.com/anchorbrowser"
     }
+  },
+  "integrations": {
+    "posthog": {
+      "apiKey": "phc_Glt3S5wLjDhBxQXiauvIHMh4h9P2BAWIsEqyQPwkwC5"
+    }
   }
 }


### PR DESCRIPTION
Adds PostHog tracking integration with Mintlify, as per Mintlify docs: https://www.mintlify.com/docs/integrations/analytics/posthog